### PR TITLE
Update osdep_service.c

### DIFF
--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2290,7 +2290,7 @@ static int storeToFile(const char *path, u8 *buf, u32 sz)
 			oldfs = get_fs();
 			set_fs(KERNEL_DS);
 			#else
-			set_fs(get_ds());
+			#set_fs(get_ds());
 			#endif
 			ret = writeFile(fp, buf, sz);
 			#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))


### PR DESCRIPTION
The driver support of rtl8188* is currently disabled on armbian, so I took the time to check whats up.
see: https://github.com/armbian/build/commit/c7cc1825cd9f69bebfdbe230543374da75cef566

Commenting out invalid else branch because of deprecated get_ds() functions which breaks the build (e.g. on armbian)